### PR TITLE
[Lab5] Adding CLI commands to show tx error status and configure relevant parameters 

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -7068,5 +7068,33 @@ def del_subinterface(ctx, subinterface_name):
     except JsonPatchConflict as e:
         ctx.fail("{} is invalid vlan subinterface. Error: {}".format(subinterface_name, e))
 
+
+#
+# 'txargs_threshold' command
+#
+@config.command('txargs_threshold')
+@click.argument('new_threshold', metavar='<new_threshold>', required=True, type=click.IntRange(0, 4294967295))
+def txargs_threshold(new_threshold):
+
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    config_db.mod_entry("TX_ERROR_MONITOR", 'config',
+                        {'threshold': new_threshold})
+
+
+#
+# 'txargs_duration' command
+#
+@config.command('txargs_duration')
+@click.argument('new_duration', metavar='<new_duration>', required=True, type=click.IntRange(1, 4294967295))
+def txargs_duration(new_duration):
+
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    config_db.mod_entry("TX_ERROR_MONITOR", 'config',
+                        {'duration': new_duration})
+
+
+
 if __name__ == '__main__':
     config()

--- a/show/main.py
+++ b/show/main.py
@@ -2029,6 +2029,53 @@ def peer(db, peer_ip):
     click.echo(tabulate(bfd_body, bfd_headers))
 
 
+#
+# 'tx_monitor_interface' group ("show tx_monitor_interface ...")
+#
+
+@cli.group(name='tx_monitor_interface', cls=clicommon.AliasedGroup)
+def tx_monitor_interface():
+    """Show management interface parameters"""
+    pass
+
+# 'tx_fields' subcommand ("show tx_monitor_interface tx_fields")
+@tx_monitor_interface.command()
+def data ():
+    """Show data configured for tx_monitor interface"""
+
+    config_db = ConfigDBConnector()
+    config_db.connect()
+
+    # Fetching data from config_db for TX_ERROR_MONITOR
+    tx_monitor_data = config_db.get_table('TX_ERROR_MONITOR')
+    for key in natsorted(list(tx_monitor_data.keys())):
+        click.echo("{0}".format(tx_monitor_data[key]))
+
+
+#
+# 'txstate' group ("show txstate ...")
+#
+@cli.group(cls=clicommon.AliasedGroup)
+def txstate():
+    """Show details of the txstate sessions"""
+    pass
+
+# 'summary' subcommand ("show txstate summary")
+@txstate.command()
+@clicommon.pass_db
+def summary(db):
+    """Show txstate session information"""
+    txstate_keys = db.db.get_all(db.db.STATE_DB, "TX_ERROR_TABLE")
+    txstate_headers = ["Interface Name", "Tx State"]
+    txstate_entries = []
+    if txstate_keys is not None:
+        for key in natsorted(txstate_keys.keys()):
+            txstate_entries.append([key, txstate_keys[key]])
+    else:
+        click.echo("EMPTY DATA")
+    click.echo(tabulate(txstate_entries, txstate_headers, tablefmt="grid"))
+
+
 # Load plugins and register them
 helper = util_base.UtilHelper()
 helper.load_and_register_plugins(plugins, cli)


### PR DESCRIPTION
#### What I did
I Added the following CLI commands:
* **config txargs_duration [x]** - set the polling period of monitorTxOrch (doTask(timer)) to x
* **config txargs_threshold [x]** - set the threshold of tx errors to x
* **show tx_monitor_interface data** - show threshold and polling period configurations
* **show txstate summary** - show the tx state (OK/NOT OK) for each of the switch's interfaces

#### How I did it
I added these new CLI commands to /config/main.py and /show/main.py

#### How to verify it
Run these commands to configure the params:
1. "config txargs_duration 10"
2. "config txargs_threshold 100"
3. "show tx_monitor_interface data"
4. verify the result is "{'duration': '10', 'threshold': '100}"

Run this command to show tx errors status for each port:
1. "show txstate summary"

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)